### PR TITLE
Fix/manifests error

### DIFF
--- a/scaffolder-skeletons/manifests-skeleton/manifests/base/deployment.yaml
+++ b/scaffolder-skeletons/manifests-skeleton/manifests/base/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: ${{ values.repo_name }}
-          image: ${{values.image_repository}}/${{ values.image_namespace }}/${{ values.repo_name }}:latest
+          image: ${{values.image_repository}}/${{ values.image_url }}/${{ values.repo_name }}:latest
           ports:
             - name: http-${{ values.port }}
               containerPort: ${{ values.port }}

--- a/scaffolder-skeletons/manifests-skeleton/manifests/base/kustomization.yaml
+++ b/scaffolder-skeletons/manifests-skeleton/manifests/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - namespace.yaml
+  

--- a/scaffolder-skeletons/manifests-skeleton/manifests/base/kustomization.yaml
+++ b/scaffolder-skeletons/manifests-skeleton/manifests/base/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: ${{ values.namespace }}
 resources: 
   - deployment.yaml
   - service.yaml
+  - namespace.yaml

--- a/scaffolder-skeletons/manifests-skeleton/manifests/base/namespace.yaml
+++ b/scaffolder-skeletons/manifests-skeleton/manifests/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${{ values.namespace }}

--- a/scaffolder-skeletons/manifests-skeleton/manifests/base/namespace.yaml
+++ b/scaffolder-skeletons/manifests-skeleton/manifests/base/namespace.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ${{ values.namespace }}
+  


### PR DESCRIPTION
## What does this PR do / why we need it
There were two issues here, each one of them stopped the provisioning process.
By fixing this issue users will be able to run a smooth automation of application deployment end to end.

- The image that is built using a Backstage template was not being pushed to quay.io and the 
  deployment.yaml file had the wrong imaged configured.
- The cluster manifests (service + deployment) did not apply on the cluster because a namespace was missing.
## Which issue(s) does this PR fix
- The deployment.yaml manifest was configured to use 'image_namespace' as the registry namespace while in all the scaffolder templates (Python, Nodejs, etc) it's configured to pass this variable with 'image_url) name.

- Creates a namespace as part of all the manifests using the kustomization file which will allow all the other manifests apply and the ArgoCD application to sync successfully.

## Fixes 
- In the deployment.yaml file I changed the 'values.image_namespace' to 'values.image_url' to define the right image.
- I have created a namespace.yaml template file and added it to the kustomize resources list

## How to test changes / Special notes to the reviewer
- While running Backstage on top of Openshift trying to provision applications:
 I deployed the template using Backstage and saw that the generated deployment.yaml had the right image after the fix 
 while replacing 'image_url' with the quay.io namespace.
 I also checked that the pod that has created is running successfully with the image and that the image is pushed to the 
 right place on quay.io
- The namespace is now successfully created with all the other manifests and the pod is running, all automatically..
 (Tested using python template)