### PR TITLE
GitOps and Labels

### DIFF
--- a/scaffolder-templates/quarkus-web-template/manifests/helm/app/templates/_helpers.tpl
+++ b/scaffolder-templates/quarkus-web-template/manifests/helm/app/templates/_helpers.tpl
@@ -33,6 +33,10 @@ Create chart name and version as used by the chart label.
 {{/*
 Common labels
 */}}
+{{- define "backstage.labels" -}}
+backstage.io/kubernetes-id: ${{values.component_id}}
+{{- end }}
+
 {{- define "quarkus-template.labels" -}}
 backstage.io/kubernetes-id: ${{values.component_id}}
 helm.sh/chart: {{ include "quarkus-template.chart" . }}

--- a/scaffolder-templates/quarkus-web-template/manifests/helm/app/templates/deployment.yaml
+++ b/scaffolder-templates/quarkus-web-template/manifests/helm/app/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "quarkus-template.fullname" . }}
   labels:
+    {{- include "backstage.labels" . | nindent 4 }}
     {{- include "quarkus-template.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -18,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "backstage.labels" . | nindent 8 }}
         {{- include "quarkus-template.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/scaffolder-templates/quarkus-web-template/template.yaml
+++ b/scaffolder-templates/quarkus-web-template/template.yaml
@@ -70,10 +70,6 @@ spec:
           default: latest
           type: string
           description: Build Image tag
-        gitops:
-          title: Include GitOps
-          type: boolean
-          description: Should the component include a GitOps workflow
     - title: Application repository Information
       required:
         - repoUrl
@@ -123,7 +119,6 @@ spec:
         catalogInfoPath: '/catalog-info.yaml'
 
     - id: template-gitops-deployment
-      if: ${{ parameters.gitops }}
       name: Generating Deployment Resources
       action: fetch:template
       input:
@@ -145,7 +140,6 @@ spec:
         targetPath: ./tenant-gitops
 
     - id: publish-gitops
-      if: ${{ parameters.gitops }}
       name: Publishing to Resource Repository
       action: publish:github
       input:
@@ -156,7 +150,6 @@ spec:
         repoVisibility: public
 
     - id: create-argocd-resources
-      if: ${{ parameters.gitops }}
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:


### PR DESCRIPTION
## What does this PR do / why we need it

1. Removes the GitOps flag in the template as we cannot function without gitops
2. Added backstage labels to the pods the deployment creates so it shows in backstage
