### PR TITLE
Updates to fix defect where launching Intellij dev space fails

### DIFF
--- a/scaffolder-templates/quarkus-web-template/skeleton/catalog-info.yaml
+++ b/scaffolder-templates/quarkus-web-template/skeleton/catalog-info.yaml
@@ -17,7 +17,7 @@ metadata:
     - url: https://devspaces${{values.cluster}}/#https://github.com/${{values.destination}}?che-editor=che-incubator/che-code/insiders&devfilePath=.devfile-vscode.yaml
       title: CodeReady Workspaces (VS Code)
       icon: web
-    - url: https://devspaces${{values.cluster}}/#https://github.com/${{values.destination}}?che-editor=che-incubator/che-idea/next&devfilePath=.devfile-intellij.yaml
+    - url: https://devspaces${{values.cluster}}/#https://github.com/${{values.destination}}?che-editor=che-incubator/che-idea/latest&devfilePath=.devfile-intellij.yaml
       title: CodeReady Workspaces (JetBrains IntelliJ)
       icon: web
 spec:


### PR DESCRIPTION
## What does this PR do / why we need it
Launching CodeReady Workspaces JetBrains IntelliJ for Quarkus app

## Which issue(s) does this PR fix
Fix Issue where launching CodeReady Workspaces JetBrains IntelliJ for Quarkus app fails with a 404 error

Fixes #?

## How to test changes / Special notes to the reviewer
Launch CodeReady Workspaces (JetBrains IntelliJ) from the Link Provided in the Overview Tab of the application