### PR TITLE
fix(nodejs): Log the selected listen port

### DIFF
--- a/scaffolder-templates/nodejs-backend-template/skeleton/src/index.ts
+++ b/scaffolder-templates/nodejs-backend-template/skeleton/src/index.ts
@@ -11,5 +11,7 @@ router.get('/', function (req, res) {
 
 app.use('/', router)
 
-app.listen(process.env.PORT || ${{ values.port }})
-console.log('Running at port ${{ values.port }}')
+const listenPort = process.env.PORT || ${{ values.port }};
+
+app.listen(listenPort)
+console.log(`Running at port ${listenPort}`)


### PR DESCRIPTION
## What does this PR do / why we need it
Currently, the selected port from the `nodejs` template gets logged into the terminal, but in case a `PORT` is specified as an environment variable, the port from a template is still logged making it misleading.

This commit provides an alternative to the previous situation by first deciding which port will be used and after that logging the selected port.
