### PR TITLE
fix(*-ansible-job): Change template registration procedure.

### DIFF
--- a/templates/github/define-ansible-job/template.yaml
+++ b/templates/github/define-ansible-job/template.yaml
@@ -141,8 +141,9 @@ spec:
       name: Registering the Catalog Info Component
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: https://github.com/${{ parameters.githubOrg }}/${{ parameters.repoName }}/blob/${{ steps.publish.output.targetBranchName }}
         catalogInfoPath: /catalog-info.yaml
+        optional: true
 
   output:
     links:

--- a/templates/github/launch-ansible-job/template.yaml
+++ b/templates/github/launch-ansible-job/template.yaml
@@ -116,8 +116,9 @@ spec:
       name: Registering the Catalog Info Component
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl:  https://github.com/${{ parameters.githubOrg }}/${{ parameters.repoName }}/blob/${{ steps.publish.output.targetBranchName }}
         catalogInfoPath: /catalog-info.yaml
+        optional: true
 
   output:
     links:


### PR DESCRIPTION
## What does this PR do / why we need it
This PR fix a bug in the `catalog-info.yaml` registration procedure. As stated in the issue, the `register` action tries to use `${{ steps.publish.output.repoContentsUrl }}` where the publish action is `publish:github:pull-request` that doesn't have `repoContentsUrl `output.

## Which issue(s) does this PR fix

Fixes #161
